### PR TITLE
Updated Set-TargetResource

### DIFF
--- a/DSCResources/MSFT_xWinEventLog/MSFT_xWinEventLog.psm1
+++ b/DSCResources/MSFT_xWinEventLog/MSFT_xWinEventLog.psm1
@@ -74,25 +74,37 @@ function Set-TargetResource
     try
     {
         $log = Get-WinEvent -ListLog $logName
-        if ($MaximumSizeInBytes) { $log.MaximumSizeInBytes = $MaximumSizeInBytes}
-        if ($LogMode)            { $log.LogMode = $LogMode}
-        if ($SecurityDescriptor) { $log.SecurityDescriptor = $SecurityDescriptor}
-        $log.SaveChanges()
-        try
-        {
-            if ($PSBoundParameters.ContainsKey("IsEnabled")) 
-            { $log.IsEnabled = $IsEnabled}
-            $log.SaveChanges()
-        }catch
-        {
-            New-TerminatingError -errorId 'SetWinEventLogFailed' -errorMessage "`nCannot change IsEnabled on [WinEventLog]$logName" -errorCategory InvalidOperation
+        $update = $false
+
+        if ($PSBoundParameters.ContainsKey('MaximumSizeInBytes') -and $MaximumSizeInBytes -ne $log.MaximumSizeInBytes) { 
+            $log.MaximumSizeInBytes = $MaximumSizeInBytes
+            $update = $true
         }
+        
+        if ($PSBoundParameters.ContainsKey('LogMode') -and $LogMode -ne $log.LogMode){ 
+            $log.LogMode = $LogMode
+            $update = $true
+        }
+        
+        if ($PSBoundParameters.ContainsKey('SecurityDescriptor') -and $SecurityDescriptor -ne $log.SecurityDescriptor) { 
+            $log.SecurityDescriptor = $SecurityDescriptor
+            $update = $true
+        }
+        
+        if ($PSBoundParameters.ContainsKey("IsEnabled") -and $IsEnabled -ne $log.IsEnabled) { 
+            $log.IsEnabled = $IsEnabled
+            $update = $true
+        }
+        
+        if($update){$log.SaveChanges()}
+
 
     }catch
     {
-        write-Debug "ERROR: $($_|fl * -force|out-string)"
+        Write-Debug "ERROR: $($_|fl * -force|out-string)"
         New-TerminatingError -errorId 'SetWinEventLogFailed' -errorMessage $_.Exception -errorCategory InvalidOperation
     }
+
 
 }
 

--- a/DSCResources/MSFT_xWinEventLog/MSFT_xWinEventLog.psm1
+++ b/DSCResources/MSFT_xWinEventLog/MSFT_xWinEventLog.psm1
@@ -77,27 +77,21 @@ function Set-TargetResource
         $update = $false
 
         if ($PSBoundParameters.ContainsKey('MaximumSizeInBytes') -and $MaximumSizeInBytes -ne $log.MaximumSizeInBytes) { 
-            $log.MaximumSizeInBytes = $MaximumSizeInBytes
-            $update = $true
+            Set-MaximumSizeInBytes -LogName $LogName -MaximumSizeInBytes $MaximumSizeInBytes
         }
         
         if ($PSBoundParameters.ContainsKey('LogMode') -and $LogMode -ne $log.LogMode){ 
-            $log.LogMode = $LogMode
-            $update = $true
+            Set-LogMode -LogName $LogName -LogMode $LogMode
         }
         
         if ($PSBoundParameters.ContainsKey('SecurityDescriptor') -and $SecurityDescriptor -ne $log.SecurityDescriptor) { 
-            $log.SecurityDescriptor = $SecurityDescriptor
-            $update = $true
+            Set-SecurityDescriptor -LogName $LogName -SecurityDescriptor $SecurityDescriptor
         }
         
         if ($PSBoundParameters.ContainsKey("IsEnabled") -and $IsEnabled -ne $log.IsEnabled) { 
-            $log.IsEnabled = $IsEnabled
-            $update = $true
+            Set-IsEnabled -LogName $LogName -IsEnabled $IsEnabled
         }
-        
-        if($update){$log.SaveChanges()}
-
+       
 
     }catch
     {
@@ -149,7 +143,69 @@ function Test-TargetResource
     
 }
 
+Function Set-MaximumSizeInBytes{
+    [CmdletBinding()]
+    param(
+        [System.String]
+        $LogName,
 
+        [System.Int64]
+        $MaximumSizeInBytes
+
+    )
+
+    $log = Get-WinEvent -ListLog $logName
+    $log.MaximumSizeInBytes = $MaximumSizeInBytes
+    $log.SaveChanges()
+
+}
+
+Function Set-LogMode{
+    [CmdletBinding()]
+    param(
+        [System.String]
+        $LogName,
+
+        [System.String]
+        $LogMode
+    )
+
+    $log = Get-WinEvent -ListLog $LogName
+    $log.LogMode = $LogMode
+    $log.SaveChanges()
+}
+
+Function Set-SecurityDescriptor{
+    [CmdletBinding()]
+    param(
+        [System.String]
+        $LogName,
+
+        [System.String]
+        $SecurityDescriptor
+    )
+
+    $log = Get-WinEvent -ListLog $LogName
+    $log.SecurityDescriptor = $SecurityDescriptor
+    $log.SaveChanges()
+}
+
+
+Function Set-IsEnabled{
+    [CmdletBinding()]
+    param(
+        [System.String]
+        $LogName,
+
+        [System.Boolean]
+        $IsEnabled
+    )
+
+    $log = Get-WinEvent -ListLog $LogName
+    $log.IsEnabled = $IsEnabled
+    $log.SaveChanges()
+
+}
 Export-ModuleMember -Function *-TargetResource
 
 

--- a/DSCResources/MSFT_xWinEventLog/WinEvent.Tests.ps1
+++ b/DSCResources/MSFT_xWinEventLog/WinEvent.Tests.ps1
@@ -1,0 +1,131 @@
+﻿<#
+    .NOTES
+        TODO: Add Tests to validate that only the properties that don't match are updated in the set
+#>
+
+Import-Module 'C:\Program Files\WindowsPowerShell\Modules\xWinEventLog\DSCResources\MSFT_xWinEventLog\MSFT_xWinEventLog.psm1' -Prefix WinEventLog
+
+Describe 'WinEventLog Get-TargetResource'{
+    
+    Mock Get-WinEvent -ModuleName MSFT_xWinEventLog {
+        $properties = @{
+            MaximumSizeInBytes = '999'
+            IsEnabled = $true
+            LogMode = 'Test'
+            SecurityDescriptor = 'TestDescriptor'
+        }
+        
+        Write-Output (New-Object -TypeName PSObject -Property $properties)   
+    }
+
+    $results = Get-WinEventLogTargetResource 'Application'
+
+    It 'Should return an hashtable'{
+        $results.GetType().Name | Should Be 'HashTable'
+    }
+
+    It 'Should return a Hashtable name is Application'{
+        $results.LogName = 'Application'
+    }
+
+    It 'Should return a Hashatable with the MaximumSizeInBytes is 999'{
+        $results.MaximumSizeInBytes | Should Be '999'
+    }
+
+    It 'Should return a Hashtable where IsEnabled is true'{
+        $results.IsEnabled | should Be $true
+    }
+
+    It 'Should return a HashTable where LogMode is Test' {
+        $results.LogMode | Should Be 'Test'
+    }
+
+    It 'Should return a HashTable where SecurityDescriptor is TestDescriptor'{
+        $results.SecurityDescriptor | Should Be 'TestDescriptor'
+    }
+}
+
+Describe 'WinEventLog Test-TargetResource'{
+    
+    Mock Get-WinEvent -ModuleName MSFT_xWinEventLog {
+        $properties = @{
+            MaximumSizeInBytes = '5111808'
+            IsEnabled = $true
+            LogMode = 'Circular'
+            SecurityDescriptor = 'TestDescriptor'
+        }
+        
+        Write-Output (New-Object -TypeName PSObject -Property $properties)   
+    }
+
+    $params = @{
+        LogName = 'Application'
+        MaximumSizeInBytes = '5111808'
+        LogMode = 'Circular'
+        IsEnabled = $true
+        SecurityDescriptor = 'TestDescriptor'
+    }
+    
+   
+    It 'should return true when all properties match does not match'{
+        $testResults = Test-WinEventLogTargetResource @params
+        $testResults | Should Be $True
+    }
+    
+    It 'should return false when MaximumSizeInBytes does not match'{
+        $testResults = Test-WinEventLogTargetResource -LogName 'Application' -MaximumSizeInBytes '1' -IsEnabled $true -SecurityDescriptor 'TestDescriptor' -LogMode 'AutoBackup'
+        $testResults | Should Be $False
+    }
+
+    It 'should return false when LogMode does not match'{
+        $testResults = Test-WinEventLogTargetResource -LogName 'Application' -MaximumSizeInBytes '5111808' -IsEnabled $true -SecurityDescriptor 'TestDescriptor' -LogMode 'AutoBackup'
+        $testResults | Should Be $false
+    }
+
+    It 'should return false when IsEnabled does not match'{
+        $testResults = Test-WinEventLogTargetResource -LogName 'Application' -MaximumSizeInBytes '5111808' -IsEnabled $false -SecurityDescriptor 'TestDescriptor' -LogMode 'Circular'
+        $testResults | Should Be $false
+    }
+
+    It 'Should return false when SecurityDescriptor does not match'{
+        $testResults = Test-WinEventLogTargetResource -LogName 'Application' -MaximumSizeInBytes '5111808' -IsEnabled $true -SecurityDescriptor 'TestDescriptorFail' -LogMode 'Circular'
+        $testResults | Should Be $false    
+    }
+
+    It 'Should call Get-WinEventLog' {
+        Assert-MockCalled Get-WinEvent -ModuleName MSFT_xWinEventLog -Exactly 5
+    }
+}
+
+Describe 'WinEventLog Set-TargetResource'{
+    BeforeAll {
+        New-EventLog -LogName 'Pester' -Source 'PesterTest'
+        $Log = Get-WinEvent -ListLog 'Pester'
+        $Log.LogMode = 'Circular'
+        $Log.SaveChanges()
+    }
+    
+    It 'Should update the LogMode'{
+        Set-WinEventLogTargetResource -LogName 'Pester' -LogMode 'AutoBackup'
+        (Get-WinEvent -ListLog 'Pester').LogMode | Should Be 'AutoBackup'        
+    }
+
+    It 'Should update MaximumSizeInBytes' {
+        Set-WinEventLogTargetResource -LogName 'Pester' -MaximumSizeInBytes '5111800'
+        (Get-WinEvent -ListLog 'Pester').MaximumSizeInBytes | Should Be '5111800'  
+    }
+
+    It 'Should update IsEnabled to false' {
+        Set-WinEventLogTargetResource -LogName 'Pester' -IsEnabled $false
+        (Get-WinEvent -ListLog 'Pester').IsEnabled | Should Be $false
+    }
+
+    It 'Should update SecurityDescriptor' {
+        Set-WinEventLogTargetResource -LogName 'Pester' -SecurityDescriptor 'O:BAG:SYD:(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)' 
+        (Get-WinEvent -ListLog 'Pester').SecurityDescriptor = 'O:BAG:SYD:(A;;0x7;;;BA)(A;;0x7;;;SO)(A;;0x3;;;IU)(A;;0x3;;;SU)(A;;0x3;;;S-1-5-3)(A;;0x3;;;S-1-5-33)(A;;0x1;;;S-1-5-32-573)' 
+    }
+
+    AfterAll {
+        Remove-EventLog -LogName 'Pester'
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,49 @@
 
 # xWinEventLog
 
-{{Description}}
+The **xWinEventLog** module contains the **xWinEventLog** DSC resource which configures the Windows Event Logs.
 
 ## Contributing
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
+
+
+## Resources
+
+### xWinEventLog
+
+* **LogName**: Name of the event log.
+* **MaximumSizeInBytes**: Size that the event log file is allowed to be. When the file reaches this maximum size it is considered full.
+* **IsEnabled**: Specifies whether or not logging for the specified log is enabled.
+* **LogMode**: The log mode: { AutoBackup | Circular | Retained }
+* **SecurityDescriptor**: This is an SDDL string which configures access rights to the event log.
+
+## Versions
+
+### 0.0.1
+
+* Initial release with the following resource:
+    - xWinEventLog
+
+## Examples
+
+### Configuring the MSPaint event log
+
+```powershell
+$before = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin" 
+Configuration Demo1
+{
+    Import-DscResource -module xWinEventLog
+    xWinEventLog Demo1
+    {
+        LogName            = "Microsoft-Windows-MSPaint/Admin"
+        IsEnabled          = $true
+        LogMode            = "AutoBackup"
+        MaximumSizeInBytes = 20mb
+    }
+}
+Demo1 -OutputPath $env:temp
+Start-DscConfiguration -Path $env:temp -ComputerName localhost -Verbose -wait -debug
+$after = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin" 
+$before,$after | format-table -AutoSize LogName,IsEnabled,MaximumSizeInBytes,ProviderLatency,LogMode
+Get-DscConfiguration
+```

--- a/WinEvent.Tests.ps1
+++ b/WinEvent.Tests.ps1
@@ -3,7 +3,7 @@
         TODO: Add Tests to validate that only the properties that don't match are updated in the set
 #>
 
-Import-Module 'C:\Program Files\WindowsPowerShell\Modules\xWinEventLog\DSCResources\MSFT_xWinEventLog\MSFT_xWinEventLog.psm1' -Prefix WinEventLog
+Import-Module '.\DSCResources\MSFT_xWinEventLog\MSFT_xWinEventLog.psm1' -Prefix WinEventLog
 
 Describe 'WinEventLog Get-TargetResource'{
     

--- a/WinEvent.Tests.ps1
+++ b/WinEvent.Tests.ps1
@@ -3,7 +3,7 @@
        
 #>
 
-Import-Module '.\DSCResources\MSFT_xWinEventLog\MSFT_xWinEventLog.psm1' -Prefix WinEventLog -Force
+Import-Module $PSScriptRoot\DSCResources\MSFT_xWinEventLog\MSFT_xWinEventLog.psm1 -Prefix WinEventLog -Force
 
 #Getting initial Value for Capi2 Log so we can test the ability to set Isenabled to False
 #and then set it back to its original value when we're done


### PR DESCRIPTION
I updated the **Set-Target** resource to only update the Event Log Settings if they are not in the desired state.  In the process, I create a private function for each property that can be set, LogMode, MaximumSizeInBytes, SecurityDescriptor.  It makes it easier to test.  I also added tests to ensure that Set-TargetResource is not called if the desired value is passed. 
