### PR TITLE
Adds xEventLog resource - Fixes #10

### DIFF
--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
@@ -1,0 +1,151 @@
+﻿function New-TerminatingError
+{
+    param
+    (
+        [Parameter(Mandatory)]
+        [String]$errorId,
+
+        [Parameter(Mandatory)]
+        [String]$errorMessage,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorCategory]$errorCategory
+    )
+
+    $exception   = New-Object System.InvalidOperationException $errorMessage
+    $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $errorCategory, $null
+    throw $errorRecord
+}
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $LogName
+    )
+
+    try
+    {
+        $log = Get-EventLog -LogName $LogName
+        $returnValue = @{
+            LogName = [System.String]$LogName
+            Source = @($log.Source)
+        }
+
+        return $returnValue
+    }catch
+    {
+        write-Debug "ERROR: $($_ | Format-List * -force | Out-String)"
+        New-TerminatingError -errorId 'GetEventLogFailed' -errorMessage $_.Exception -errorCategory InvalidOperation
+    }
+}
+
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $LogName,
+
+        [System.String[]]
+        $Source
+    )
+
+
+    try
+    {
+        $currentEventLog = Get-TargetResource -LogName $LogName
+    }
+    catch
+    {
+        try
+        {
+            Write-Verbose -Message "Creating $LogName with sources specified: $Source"
+            New-EventLog -LogName $LogName -Source $Source -ErrorAction Stop
+        }
+        catch
+        {
+            Write-Debug "ERROR: $($_ | Format-List * -force | Out-String)"
+            New-TerminatingError -errorId 'SetEventLogFailed' -errorMessage $_.Exception -errorCategory InvalidOperation
+        }
+    }
+
+    if ($currentEventLog)
+    {
+        $missingSource = Compare-Object -ReferenceObject $currentEventLog.Source -DifferenceObject $Source | Where-Object {$_.SideIndicator -eq '=>'}
+
+        try
+        {
+            Write-Verbose -Message "Updating $LogName with sources specified: $Source"
+            New-EventLog -LogName $LogName -Source $missingSource -ErrorAction Stop
+            $Source = $missingSource
+        }
+        catch
+        {
+            Write-Debug "ERROR: $($_ | Format-List * -force | Out-String)"
+            New-TerminatingError -errorId 'SetEventLogFailed' -errorMessage $_.Exception -errorCategory InvalidOperation
+        }
+    }
+
+    Foreach ($eventSource in $Source)
+    {
+        Write-Verbose -Message "Adding an event log entry for $eventSource to $LogName to populate it for future checks."
+
+        $writeEventLogParams = @{
+            LogName = $LogName
+            Source = $eventSource
+            EntryType = "Information"
+            EventId = 0
+            Message = "Populating $LogName using $eventSource to ensure future DSC consistency checks don't attempt to recreate this."
+        }
+
+        Write-EventLog @writeEventLogParams
+    }
+
+}
+
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $LogName,
+
+        [System.String[]]
+        $Source
+    )
+
+    try
+    {
+        Write-Verbose -Message "Checking for $LogName."
+        $log = Get-TargetResource -LogName $LogName
+        If ($Log.Source -ne $Source) {
+            Write-Verbose -Message "$LogName found but sources do not match."
+            return $false
+        }
+        Write-Verbose -Message "$LogName found."
+        return $true
+    }
+    catch
+    {
+        Write-Verbose -Message "$LogName not found."
+        return $false
+    }
+
+}
+
+Export-ModuleMember -Function *-TargetResource
+
+
+

--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
@@ -79,12 +79,14 @@ function Set-TargetResource
 
     if ($currentEventLog)
     {
-        $missingSource = Compare-Object -ReferenceObject $currentEventLog.Source -DifferenceObject $Source | Where-Object {$_.SideIndicator -eq '=>'}
+        $missingSource = Compare-Object -ReferenceObject $currentEventLog.Source -DifferenceObject $Source |
+                Where-Object {$_.SideIndicator -eq '=>'} |
+                    Select-Object -ExpandProperty InputObject
 
         try
         {
             Write-Verbose -Message "Updating $LogName with sources specified: $Source"
-            New-EventLog -LogName $LogName -Source $missingSource.InputObject -ErrorAction Stop
+            New-EventLog -LogName $LogName -Source $missingSource -ErrorAction Stop
             $Source = $missingSource
         }
         catch

--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
@@ -2,13 +2,13 @@
 {
     param
     (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]$errorId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [String]$errorMessage,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory = $true)]
         [System.Management.Automation.ErrorCategory]$errorCategory
     )
 
@@ -23,13 +23,14 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $LogName
     )
 
     try
     {
+        Write-Verbose -Message "Getting $LogName details."
         $log = Get-EventLog -LogName $LogName
         $returnValue = @{
             LogName = [System.String]$LogName
@@ -50,10 +51,11 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $LogName,
 
+        [Parameter()]
         [System.String[]]
         $Source
     )
@@ -120,10 +122,11 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $LogName,
 
+        [Parameter()]
         [System.String[]]
         $Source
     )
@@ -132,7 +135,8 @@ function Test-TargetResource
     {
         Write-Verbose -Message "Checking for $LogName."
         $log = Get-TargetResource -LogName $LogName
-        If ($Log.Source -ne $Source) {
+        If ($Log.Source -ne $Source)
+        {
             Write-Verbose -Message "$LogName found but sources do not match."
             return $false
         }

--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.psm1
@@ -84,7 +84,7 @@ function Set-TargetResource
         try
         {
             Write-Verbose -Message "Updating $LogName with sources specified: $Source"
-            New-EventLog -LogName $LogName -Source $missingSource -ErrorAction Stop
+            New-EventLog -LogName $LogName -Source $missingSource.InputObject -ErrorAction Stop
             $Source = $missingSource
         }
         catch

--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.schema.mof
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.schema.mof
@@ -1,0 +1,10 @@
+
+[ClassVersion("1.0.0.1"), FriendlyName("xEventLog")]
+class MSFT_xEventLog : OMI_BaseResource
+{
+    [Key, Description("Name of the event log")] String LogName;
+    [Write, Description("Specifies the names of the event log sources.")] String Source;
+};
+
+
+

--- a/DSCResources/MSFT_xEventLog/MSFT_xEventLog.schema.mof
+++ b/DSCResources/MSFT_xEventLog/MSFT_xEventLog.schema.mof
@@ -3,7 +3,7 @@
 class MSFT_xEventLog : OMI_BaseResource
 {
     [Key, Description("Name of the event log")] String LogName;
-    [Write, Description("Specifies the names of the event log sources.")] String Source;
+    [Write, Description("Specifies the names of the event log sources.")] String Source[];
 };
 
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **LogMode**: The log mode: { AutoBackup | Circular | Retained }
 * **SecurityDescriptor**: This is an SDDL string which configures access rights to the event log.
 
+### xEventLog
+
+* **LogName**: Name of the event log.
+* **Source**: Source(s) to create.
+
+
 ## Versions
 
 ### Unreleased
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* xEventLog added to allow creating new event logs with various sources.
 
 ### 1.1.0.0
 
@@ -46,7 +53,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### Configuring the MSPaint event log
 
 ```powershell
-$before = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin" 
+$before = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin"
 Configuration Demo1
 {
     Import-DscResource -module xWinEventLog
@@ -61,7 +68,7 @@ Configuration Demo1
 }
 Demo1 -OutputPath $env:temp
 Start-DscConfiguration -Path $env:temp -ComputerName localhost -Verbose -wait -debug
-$after = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin" 
+$after = Get-WinEvent -ListLog "Microsoft-Windows-MSPaint/Admin"
 $before,$after | format-table -AutoSize LogName,IsEnabled,MaximumSizeInBytes,ProviderLatency,LogMode
 Get-DscConfiguration
 ```

--- a/Tests/Unit/EventLog.Tests.ps1
+++ b/Tests/Unit/EventLog.Tests.ps1
@@ -94,7 +94,6 @@ InModuleScope MSFT_xEventLog {
 
         Context 'When set is called and event log does not exist' {
             Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
-            #mock -CommandName New-EventLog -MockWith {}
 
             It 'Should create the event log with a single source' {
                 mock -CommandName New-EventLog -MockWith {}
@@ -104,6 +103,16 @@ InModuleScope MSFT_xEventLog {
                 Assert-MockCalled -CommandName Write-EventLog -Exactly -Times 1
             }
 
+            It 'Should throw an error if it fails to create the new event log'{
+                Mock -CommandName New-EventLog -MockWith {Throw}
+                { Set-EventLogTargetResource -LogName 'Pester' -Source 'ErrorSource' } | Should Throw
+            }
+
+        }
+
+        Context 'When set is called and event log does not exist with multiple sources' {
+            Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
+
             It 'Should create the event log with multiple sources' {
                 mock -CommandName New-EventLog -MockWith {}
                 Set-EventLogTargetResource -LogName 'Pester' -Source @('SetTargetResource','TestTargetResource')
@@ -111,12 +120,6 @@ InModuleScope MSFT_xEventLog {
                 Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
                 Assert-MockCalled -CommandName Write-EventLog -Exactly -Times 2
             }
-
-            It 'Should throw an error if it fails to create the new event log'{
-                Mock -CommandName New-EventLog -MockWith {Throw}
-                { Set-EventLogTargetResource -LogName 'Pester' -Source 'ErrorSource' } | Should Throw
-            }
-
         }
 
         Context "When EventLog exists but Sources don't match" {

--- a/Tests/Unit/EventLog.Tests.ps1
+++ b/Tests/Unit/EventLog.Tests.ps1
@@ -92,7 +92,7 @@ Describe 'EventLog Set-TargetResource'{
     Mock -CommandName Write-Verbose -MockWith {}
 
     Context 'When set is called and event log does not exist' {
-        Mock -CommandName New-EventLog -MockWith { $true }
+        Mock -CommandName New-EventLog -MockWith { $true } -ParameterFilter { $LogName -eq 'Pester'}
         Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
 
         It 'Should create the event log' {
@@ -107,7 +107,7 @@ Describe 'EventLog Set-TargetResource'{
         }
     }
 
-    Context "When EventLog exists but Sources don't match"{
+    Context "When EventLog exists but Sources don't match" {
         Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith {
             [psobject]@{
                 LogName = 'Pester'

--- a/Tests/Unit/EventLog.Tests.ps1
+++ b/Tests/Unit/EventLog.Tests.ps1
@@ -88,22 +88,22 @@ Describe 'EventLog Test-TargetResource'{
 }
 
 Describe 'EventLog Set-TargetResource'{
-    Mock -CommandName Write-EventLog -MockWith {}
+    #Mock -CommandName Write-EventLog -MockWith {}
     Mock -CommandName Write-Verbose -MockWith {}
 
     Context 'When set is called and event log does not exist' {
-        Mock -CommandName New-EventLog -MockWith { $true } -ParameterFilter { $LogName -eq 'Pester'}
         Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
-
-        It 'Should create the event log' {
-            Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource'
-            Assert-MockCalled -CommandName New-EventLog -Exactly -Times 1
-            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
-        }
 
         It 'Should throw an error if it fails to create the new event log'{
             Mock -CommandName New-EventLog -MockWith {Throw}
             { Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource' } | Should Throw
+        }
+
+        It 'Should create the event log' {
+            Mock -CommandName New-EventLog -MockWith { $true }
+            Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource'
+            Assert-MockCalled -CommandName New-EventLog -Exactly -Times 1
+            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
         }
     }
 

--- a/Tests/Unit/EventLog.Tests.ps1
+++ b/Tests/Unit/EventLog.Tests.ps1
@@ -1,0 +1,118 @@
+﻿    <#
+    .NOTES
+
+#>
+
+Import-Module $PSScriptRoot\..\..\DSCResources\MSFT_xEventLog\MSFT_xEventLog.psm1 -Prefix EventLog -Force
+
+Describe 'EventLog Get-TargetResource'{
+
+    Mock -CommandName Write-Verbose -MockWith {}
+
+    Mock Get-EventLog -ModuleName MSFT_xEventLog {
+        $properties = @{
+            Source = 'Application1'
+        }
+
+        Write-Output (New-Object -TypeName PSObject -Property $properties)
+    }
+
+    $results = Get-EventLogTargetResource 'Application'
+
+    It 'Should return an hashtable'{
+        $results.GetType().Name | Should Be 'HashTable'
+    }
+
+    It 'Should return a Hashtable LogName is Pester'{
+        $results.LogName = 'Pester'
+    }
+
+    It 'Should return a Hashatable with the Source is Application1'{
+        $results.Source | Should Be 'Application1'
+    }
+}
+
+Describe 'EventLog Test-TargetResource'{
+
+    Mock -CommandName Write-Verbose -MockWith {}
+
+    Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith {
+        $properties = @{
+            Source = 'Application1'
+        }
+
+        Write-Output (New-Object -TypeName PSObject -Property $properties)
+    } -ParameterFilter {$LogName -eq 'Pester'}
+
+    Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith {
+        $properties = @{
+            Source = @('Application1','Application2')
+        }
+
+        Write-Output (New-Object -TypeName PSObject -Property $properties)
+    } -ParameterFilter {$LogName -eq 'ArrayOfSources'}
+
+    Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith {
+        Throw "Event Log $LogName doesn't exist"
+    } -ParameterFilter {$LogName -eq 'NotExisting'}
+
+    $params = @{
+        LogName = 'Pester'
+        Source = 'Application1'
+    }
+
+
+    It 'should return true when all properties match'{
+        $testResults = Test-EventLogTargetResource @params
+        $testResults | Should Be $True
+    }
+
+    It 'should return false when Source does not match'{
+        $testResults = Test-EventLogTargetResource -LogName 'Pester' -Source 'Application2'
+        $testResults | Should Be $False
+    }
+
+    It 'should return false when an array of Sources does not match'{
+        $testResults = Test-EventLogTargetResource -LogName 'ArrayOfSources' -Source @('Application2','Application3')
+        $testResults | Should Be $False
+    }
+
+    It 'should return false when LogName does not exist'{
+        $testResults = Test-EventLogTargetResource -LogName 'NotExisting' -Source 'Application2'
+        $testResults | Should Be $False
+    }
+
+    It 'Should call Get-TargetResource' {
+        Assert-MockCalled Get-TargetResource -ModuleName MSFT_xEventLog -Exactly -Times 4
+    }
+}
+
+Describe 'EventLog Set-TargetResource'{
+    Mock -CommandName Write-EventLog -MockWith {}
+    Mock -CommandName Write-Verbose -MockWith {}
+    Mock -CommandName New-EventLog -MockWith { $true }
+
+
+    Context 'When set is called and event log does not exist' {
+        Mock -CommandName New-EventLog -MockWith { $true }
+        Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
+
+        It 'Should create the event log' {
+            Mock -CommandName New-EventLog -MockWith { $true }
+            Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource'
+            Assert-MockCalled -CommandName New-EventLog -Exactly -Times 1
+            Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
+        }
+
+        It 'Should throw an error if it fails to create the new event log'{
+            Mock -CommandName New-EventLog -MockWith {Throw}
+            { Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource' } | Should Throw
+        }
+    }
+
+    Context "When EventLog exists but Sources don't match"{
+
+
+    }
+
+}

--- a/Tests/Unit/EventLog.Tests.ps1
+++ b/Tests/Unit/EventLog.Tests.ps1
@@ -94,12 +94,22 @@ InModuleScope MSFT_xEventLog {
 
         Context 'When set is called and event log does not exist' {
             Mock -CommandName Get-TargetResource -ModuleName MSFT_xEventLog -MockWith { Throw }
-            mock -CommandName New-EventLog -MockWith {} -ParameterFilter {$LogName -eq 'Pester' -and $Source -eq 'SetTargetResource'}
+            #mock -CommandName New-EventLog -MockWith {}
 
-            It 'Should create the event log' {
+            It 'Should create the event log with a single source' {
+                mock -CommandName New-EventLog -MockWith {}
                 Set-EventLogTargetResource -LogName 'Pester' -Source 'SetTargetResource'
                 Assert-MockCalled -CommandName New-EventLog -Exactly -Times 1 -ParameterFilter {$LogName -eq 'Pester' -and $Source -eq 'SetTargetResource'}
                 Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
+                Assert-MockCalled -CommandName Write-EventLog -Exactly -Times 1
+            }
+
+            It 'Should create the event log with multiple sources' {
+                mock -CommandName New-EventLog -MockWith {}
+                Set-EventLogTargetResource -LogName 'Pester' -Source @('SetTargetResource','TestTargetResource')
+                Assert-MockCalled -CommandName New-EventLog -Exactly -Times 1 -ParameterFilter {$LogName -eq 'Pester' -and $Source -Contains 'TestTargetResource'}
+                Assert-MockCalled -CommandName Get-TargetResource -Exactly -Times 1
+                Assert-MockCalled -CommandName Write-EventLog -Exactly -Times 2
             }
 
             It 'Should throw an error if it fails to create the new event log'{


### PR DESCRIPTION
This adds a new resource called xEventLog (kind of clashes with xWinEventLog) and it creates a new event log with associated Source(s). To ensure the Test-TargetResource method passes on future runs the Set-TargetResource method will write an entry to the new EventLog for each source specified.

There are a suite of Pester tests added in the usual folder structure, I'll submit another PR to move the existing tests into the same location to maintain consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xwineventlog/14)
<!-- Reviewable:end -->
